### PR TITLE
Little fix to avoid '.*imgformat*.vtf' file naming

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1230,7 +1230,7 @@ void CMainWindow::saveVTFToFile()
 
 	QString filePath = QFileDialog::getSaveFileName(
 		this, "Save VTF",
-		recentPaths.last(), "*.vtf", nullptr,
+		QFileInfo( recentPaths.last() ).completeBaseName(), "*.vtf", nullptr,
 		QFileDialog::Option::DontUseNativeDialog );
 
 	if ( filePath.isEmpty() )


### PR DESCRIPTION
Fixes file name as `filename.ext.vtf` when saving